### PR TITLE
Add touched-at label to naisplated files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,12 @@ ROOT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 test:
 	rm -rf ./test/out/*
-	./naisplater --filter "*file" dev ./test/templates ./test/vars ./test/out supersecret69
+	./naisplater --filter "*file" --touched-at testingtime dev ./test/templates ./test/vars ./test/out supersecret69
 	diff ./test/out ./test/expected && echo "OK" || (echo "FAILED" && exit 1)
 
 docker-test:
-	docker run -v ${ROOT_DIR}/test/templates:/templates -v ${ROOT_DIR}/test/vars:/vars -v ${ROOT_DIR}/test/out:/out --rm ${IMAGE} naisplater --filter "*file" dev /templates /vars /out supersecret69
+	sudo rm -rf ./test/out/*
+	docker run -v ${ROOT_DIR}/test/templates:/templates -v ${ROOT_DIR}/test/vars:/vars -v ${ROOT_DIR}/test/out:/out --rm ${IMAGE} naisplater --filter "*file" --touched-at testingtime dev /templates /vars /out supersecret69
 	diff ./test/out ./test/expected && echo "OK" || (echo "FAILED" && exit 1)
 
 bump:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Options:
     -h|--help         show this help
     -f|--filter       only process files matching this glob
     -n|--no-label     do not add the nais.io/created-by label
+    -t|--touched-at   value to use for nais.io/touched-at label (default is current time)
 ```
 
 Full example (see also [test folder](https://github.com/nais/naisplater/tree/master/test))
@@ -73,4 +74,4 @@ mysecret.enc: U2FsdGVkX1/wy7efToqNXuQjSBYCC8F0hMBdHTQFVc0=
 - After processing the template, it will check the files for unresolved variables and error out if it finds any
 - Note that variable files _must_ have same name as template file
 - The environment provided as a argument is available as variable `{{ .env }}`
-- Uses [tsg/gotpl](https://github.com/tsg/gotpl) for processing go templates and [mikefarah/yq](https://github.com/mikefarah/yq) for merging yaml
+- Uses [tsg/gotpl](https://github.com/tsg/gotpl) for processing go templates and [mikefarah/yq](https://github.com/mikefarah/yq) (version 2.3.0) for merging yaml

--- a/naisplater
+++ b/naisplater
@@ -15,9 +15,9 @@ check_for_unresolved() {
   fi
 }
 
-add_created_by_label() {
+add_labels() {
   if [[ -z $NO_LABEL ]]; then
-    cat - | yq write -d '*' - "metadata.labels[nais.io/created-by]" nais-yaml
+    cat - | yq write -d '*' - "metadata.labels[nais.io/created-by]" nais-yaml | yq write -d '*' - "metadata.labels[nais.io/touched-at]" "${TOUCHED_AT}"
   else
     cat -
   fi
@@ -84,14 +84,16 @@ decryption_key        secret to use for decrypting secret variables
 Options:
     -h|--help         show this help
     -f|--filter       only process files matching this glob
-    -n|--no-label     do not add the nais.io/created-by label
+    -n|--no-label     do not add the nais.io/ labels
+    -t|--touched-at   value to use for nais.io/touched-at label (default is current time)
 EOF
 }
 
 main() {
 
+  TOUCHED_AT=$(date --utc +%Y%m%dT%H%M%S)
 
-  if ! TEMP=$(getopt --name naisplater --options 'hnf:' --longoptions 'help,no-label,filter:' -- "$@"); then
+  if ! TEMP=$(getopt --name naisplater --options 'hnf:t:' --longoptions 'help,no-label,filter:,touched-at:' -- "$@"); then
     echo "Error parsing arguments..." >&2
     exit 1
   fi
@@ -111,6 +113,10 @@ main() {
       ;;
       '-f'|'--filter')
         FILTER="${2}"
+        shift 2
+      ;;
+      '-t'|'--touched-at')
+        TOUCHED_AT="${2}"
         shift 2
       ;;
       '--')
@@ -150,7 +156,7 @@ main() {
     local output_file="${OUTPUT_DIR}/${file_name}"
 
     echo "Parsing ${file_path} to create ${output_file}..." 1>&2
-    get_yaml "${file_name}" | decrypt | gotpl "${file_path}" | add_created_by_label > "${output_file}"
+    get_yaml "${file_name}" | decrypt | gotpl "${file_path}" | add_labels > "${output_file}"
 
     ret_val=$?
     if [ $ret_val -ne 0 ]; then

--- a/test/expected/anotherfile
+++ b/test/expected/anotherfile
@@ -2,3 +2,4 @@ key: overridden
 metadata:
   labels:
     nais.io/created-by: nais-yaml
+    nais.io/touched-at: testingtime

--- a/test/expected/file
+++ b/test/expected/file
@@ -2,3 +2,4 @@ key: value is overridden in environment dev
 metadata:
   labels:
     nais.io/created-by: nais-yaml
+    nais.io/touched-at: testingtime

--- a/test/expected/multifile
+++ b/test/expected/multifile
@@ -2,13 +2,16 @@ key: value
 metadata:
   labels:
     nais.io/created-by: nais-yaml
+    nais.io/touched-at: testingtime
 ---
 key2: value
 metadata:
   labels:
     nais.io/created-by: nais-yaml
+    nais.io/touched-at: testingtime
 ---
 key3: value
 metadata:
   labels:
     nais.io/created-by: nais-yaml
+    nais.io/touched-at: testingtime

--- a/test/expected/secretfile
+++ b/test/expected/secretfile
@@ -2,3 +2,4 @@ key: ohsosecret is the secret
 metadata:
   labels:
     nais.io/created-by: nais-yaml
+    nais.io/touched-at: testingtime


### PR DESCRIPTION
This add a "touched-at" label to naisplated resources.

By default this will use an ISO8601 formatted timestamp, but the user can optionally pass in any value they want that is a valid kubernets label value.

The intention here is to make use of this feature in the nais-yaml workflow, where this can be used to implement removal of resources no longer wanted.

Even if we don't want to do that automatically, this label will be very useful when doing manual cleanup or debugging.
